### PR TITLE
EXPERTS_DB_SERVICE_NAME and tnsnames.ora example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ must be set.
 
 One option is to set these environment variables in a `.env` file. See `env.dist` for an example.
 
+`EXPERTS_DB_SERVICE_NAME` must identify an Oracle tnsnames connection string.
+
+```
+# Example env
+EXPERTS_DB_SERVICE_NAME=hoteltst.oit
+
+# $ORACLE_HOME/network/admin/tnsnames.ora
+hoteltst.oit =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(Host = oracle-hotel-tst.oit.umn.edu)(Port = 1521))
+    (CONNECT_DATA =
+      (SERVICE_NAME = hoteltst.oit)
+    )
+  )
+```
+
 ### pyenv, venv, and poetry 
 
 To install and manage Python versions we use [pyenv](https://github.com/pyenv/pyenv), and to manage

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ EXPERTS_DB_SERVICE_NAME=hoteltst.oit
 # $ORACLE_HOME/network/admin/tnsnames.ora
 hoteltst.oit =
   (DESCRIPTION =
-    (ADDRESS = (PROTOCOL = TCP)(Host = oracle-hotel-tst.oit.umn.edu)(Port = 1521))
+    (ADDRESS = (PROTOCOL = TCP)(Host = oracle-instance-domain.umn.edu)(Port = 1521))
     (CONNECT_DATA =
       (SERVICE_NAME = hoteltst.oit)
     )


### PR DESCRIPTION
Adds a sample tnsnames.ora DSN string example to the README, describing its mapping to `EXPERTS_DB_SERVICE_NAME`