### PR TITLE
Replaces raw dotenv load with dotenv_swtich.auto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,7 @@ celerybeat-schedule
 *.sage.py
 
 # dotenv
-.env
+.env*
 
 # virtualenv
 .venv

--- a/experts_etl/edw_to_pure/person.py
+++ b/experts_etl/edw_to_pure/person.py
@@ -1,5 +1,4 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch
 import os
 from datetime import datetime
 from experts_dw import db

--- a/experts_etl/edw_to_pure/person.py
+++ b/experts_etl/edw_to_pure/person.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 import os
 from datetime import datetime
 from experts_dw import db

--- a/experts_etl/edw_to_pure/user.py
+++ b/experts_etl/edw_to_pure/user.py
@@ -1,5 +1,4 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch
 import os
 from datetime import datetime
 from experts_dw import db

--- a/experts_etl/edw_to_pure/user.py
+++ b/experts_etl/edw_to_pure/user.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 import os
 from datetime import datetime
 from experts_dw import db

--- a/experts_etl/oit_to_edw/person.py
+++ b/experts_etl/oit_to_edw/person.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 import json
 import re
 import uuid

--- a/experts_etl/oit_to_edw/person.py
+++ b/experts_etl/oit_to_edw/person.py
@@ -1,5 +1,4 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch
 import json
 import re
 import uuid

--- a/experts_etl/transformer_loaders/pure_api_external_org.py
+++ b/experts_etl/transformer_loaders/pure_api_external_org.py
@@ -1,5 +1,4 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch
 import json
 from experts_dw import db
 from sqlalchemy import and_, func
@@ -10,7 +9,7 @@ from pureapi import response
 # defaults:
 
 db_name = 'hotel'
-transaction_record_limit = 100 
+transaction_record_limit = 100
 # Named for the Pure API endpoint:
 pure_api_record_type = 'external-organisations'
 pure_api_record_logger = loggers.pure_api_record_logger(type=pure_api_record_type)
@@ -83,14 +82,14 @@ def run(
   with db.session(db_name) as session:
     processed_api_org_uuids = []
     for db_api_org in extract_api_orgs(session):
-      api_org = response.transform(pure_api_record_type, json.loads(db_api_org.json))      
+      api_org = response.transform(pure_api_record_type, json.loads(db_api_org.json))
       db_org = get_db_org(session, db_api_org.uuid)
       if db_org:
         if db_org.pure_modified and db_org.pure_modified >= db_api_org.modified:
           # Skip this record, since we already have a newer one:
           processed_api_org_uuids.append(db_api_org.uuid)
           continue
-      else:   
+      else:
         db_org = create_db_org(api_org)
 
       db_org.name_en = api_org.name[0].value

--- a/experts_etl/transformer_loaders/pure_api_external_org.py
+++ b/experts_etl/transformer_loaders/pure_api_external_org.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 import json
 from experts_dw import db
 from sqlalchemy import and_, func

--- a/experts_etl/transformer_loaders/pure_api_external_person.py
+++ b/experts_etl/transformer_loaders/pure_api_external_person.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 import json
 import uuid
 from experts_dw import db

--- a/experts_etl/transformer_loaders/pure_api_internal_org.py
+++ b/experts_etl/transformer_loaders/pure_api_internal_org.py
@@ -1,5 +1,4 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch
 import json
 from experts_dw import db
 from sqlalchemy import and_, func
@@ -10,7 +9,7 @@ from pureapi import client, response
 # defaults:
 
 db_name = 'hotel'
-transaction_record_limit = 100 
+transaction_record_limit = 100
 # Named for the Pure API endpoint:
 pure_api_record_type = 'organisational-units'
 pure_api_record_logger = loggers.pure_api_record_logger(type=pure_api_record_type)
@@ -72,10 +71,10 @@ def load_db_dept_orgs(session, api_org):
     for _id in api_org.ids:
         if _id.typeUri.split('/')[-1] != 'peoplesoft_deptid':
             continue
-  
+
         deptid = _id.value
         pure_org_id = get_pure_id(api_org)
-  
+
         db_dept_org = session.query(UmnDeptPureOrg).filter(
             UmnDeptPureOrg.deptid == deptid
         ).one_or_none()
@@ -94,7 +93,7 @@ def get_pure_org(pure_org_uuid):
   pure_org = None
   try:
     r = client.get(pure_api_record_type + '/' + pure_org_uuid)
-    pure_org = response.transform(pure_api_record_type, r.json())      
+    pure_org = response.transform(pure_api_record_type, r.json())
   except Exception:
     pass
   return pure_org
@@ -209,14 +208,14 @@ def run(
   with db.session(db_name) as session:
     processed_api_org_uuids = []
     for db_api_org in extract_api_orgs(session):
-      api_org = response.transform(pure_api_record_type, json.loads(db_api_org.json))      
+      api_org = response.transform(pure_api_record_type, json.loads(db_api_org.json))
       db_org = get_db_org(session, db_api_org.uuid)
       if db_org:
         if db_org.pure_modified and db_org.pure_modified >= db_api_org.modified:
           # Skip this record, since we already have a newer one:
           processed_api_org_uuids.append(db_api_org.uuid)
           continue
-      else:   
+      else:
         db_org = create_db_org(api_org)
 
       # TODO: This needs work! Fix pureapi.response.

--- a/experts_etl/transformer_loaders/pure_api_internal_org.py
+++ b/experts_etl/transformer_loaders/pure_api_internal_org.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 import json
 from experts_dw import db
 from sqlalchemy import and_, func

--- a/experts_etl/transformer_loaders/pure_api_internal_person.py
+++ b/experts_etl/transformer_loaders/pure_api_internal_person.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 import json
 import re
 import uuid

--- a/experts_etl/transformer_loaders/pure_api_internal_person.py
+++ b/experts_etl/transformer_loaders/pure_api_internal_person.py
@@ -1,5 +1,4 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch
 import json
 import re
 import uuid
@@ -12,7 +11,7 @@ from pureapi import response
 # defaults:
 
 db_name = 'hotel'
-transaction_record_limit = 100 
+transaction_record_limit = 100
 # Named for the Pure API endpoint:
 pure_api_record_type = 'persons'
 pure_api_record_logger = loggers.pure_api_record_logger(type=pure_api_record_type)
@@ -104,7 +103,7 @@ def run(
   with db.session(db_name) as session:
     processed_api_person_uuids = []
     for db_api_person in extract_api_persons(session):
-      api_person = response.transform(pure_api_record_type, json.loads(db_api_person.json))      
+      api_person = response.transform(pure_api_record_type, json.loads(db_api_person.json))
 
       person_ids = get_person_ids(api_person)
       # Not sure that we should be requiring either of these in EDW, but we do for now,
@@ -128,13 +127,13 @@ def run(
           # Skip this record, since we already have a newer one:
           processed_api_person_uuids.append(db_api_person.uuid)
           continue
-      else:   
+      else:
         db_person = create_db_person(person_ids['emplid'])
 
       # All internal persons should have this. Usually it will be the same as the emplid,
       # but sometimes the old SciVal identifier.
       db_person.pure_id = api_person.externalId
-    
+
       db_person.pure_uuid = api_person.uuid
       db_person.internet_id = person_ids['internet_id']
       db_person.first_name = api_person.name.firstName
@@ -151,19 +150,19 @@ def run(
       #    For now, we'll skip that person.
 
       # Check for orgs not in EDW yet:
-    
+
       api_org_uuids = set()
       for org_assoc in api_person.staffOrganisationAssociations:
         api_org_uuids.add(org_assoc.organisationalUnit.uuid)
-    
+
       db_org_uuids = set()
       if db_person_previously_existed:
         # Avoid trying to query a person that doesn't exist in the db yet:
         db_org_uuids = {db_org.pure_uuid for db_org in db_person.pure_orgs}
-    
+
       api_only_org_uuids = api_org_uuids - db_org_uuids
       db_only_org_uuids = db_org_uuids - api_org_uuids
-    
+
       # For now, skip this person if there are any orgs referenced in the api record
       # that we don't have in EDW:
       if len(api_only_org_uuids) > 0:
@@ -179,7 +178,7 @@ def run(
       ## umn person pure orgs aka staff organisation associations aka jobs
 
       # TODO: We may encounter duplicate jobs that break our uniqueness constraints.
-    
+
       found_missing_job_description = False
       all_umn_person_pure_org_primary_keys = set()
       umn_person_pure_orgs = []
@@ -187,11 +186,11 @@ def run(
         if 'value' not in org_assoc.jobDescription[0]:
           found_missing_job_description = True
           break
-    
+
         # Due to transitioning from master list to xml syncs of jobs, we may encounter duplicates.
         # This may also happen due to manual entering of jobs in the Pure UI.
         umn_person_pure_org_primary_keys = frozenset([
-          'person_uuid:' + db_person.uuid, 
+          'person_uuid:' + db_person.uuid,
           'pure_org_uuid:' + org_assoc.organisationalUnit.uuid,
           'job_description:' + org_assoc.jobDescription[0].value,
           'start_date:' + org_assoc.period.startDate,
@@ -207,7 +206,7 @@ def run(
           )
           continue
         all_umn_person_pure_org_primary_keys.add(umn_person_pure_org_primary_keys)
-    
+
         umn_person_pure_org = UmnPersonPureOrg(
           pure_org_uuid = org_assoc.organisationalUnit.uuid,
           person_uuid = db_person.uuid,
@@ -216,12 +215,12 @@ def run(
           # Skipping this for now:
           pure_org_id = None,
           job_description = org_assoc.jobDescription[0].value,
-    
+
           # Note: Both employmentType and staffType may be missing because they are not required
           # fields in the Pure UI, which UMN staff sometimes use to enter jobs not in PeopleSoft.
-    
-          # Called employed_as in EDW, which was all 'Academic' as of 2018-06-05. 
-          # Probably due to an artifact of the old mast list upload process, or a 
+
+          # Called employed_as in EDW, which was all 'Academic' as of 2018-06-05.
+          # Probably due to an artifact of the old mast list upload process, or a
           # misunderstanding of it. The newer EDW table for upload, pure_new_staff_pos_defaults,
           # has similar values in default_employed_as, but they're the last segment of the
           # employmentType uri.
@@ -231,14 +230,14 @@ def run(
           # Also, sometimes staffType will be 'non-academic', but we allowed space in EDW
           # only for 'nonacademic':
           staff_type = re.sub('[^a-zA-Z]+', '', org_assoc.staffType[0].value.lower()) if 'value' in org_assoc.staffType[0] else None,
-    
+
           #start_date = datetime.strptime(org_assoc.period.startDate, iso_8601_format),
           start_date = transformers.iso_8601_string_to_datetime(org_assoc.period.startDate),
           end_date = transformers.iso_8601_string_to_datetime(org_assoc.period.endDate) if org_assoc.period.endDate else None,
           primary = 'Y' if org_assoc.isPrimaryAssociation == True else 'N',
         )
         umn_person_pure_orgs.append(umn_person_pure_org)
-    
+
       if found_missing_job_description:
         experts_etl_logger.info(
 	  'skipping updates: one or more org associations are missing job descriptions',
@@ -259,35 +258,35 @@ def run(
         session.add(umn_person_pure_org)
 
       ## person pure orgs
-    
+
       for org_uuid in api_only_org_uuids:
         person_pure_org = PersonPureOrg(
           person_uuid = db_person.uuid,
           pure_org_uuid = org_uuid,
         )
         session.add(person_pure_org)
-    
+
       session.query(PersonPureOrg).filter(
         PersonPureOrg.person_uuid == db_person.uuid,
         PersonPureOrg.pure_org_uuid.in_(db_only_org_uuids)
       ).delete(synchronize_session=False)
-    
+
       ## scopus ids
-    
+
       db_scopus_ids = set()
       if db_person_previously_existed:
         # Avoid trying to query a person that doesn't exist in the db yet:
         db_scopus_ids = set(db_person.scopus_ids)
       api_only_scopus_ids = person_ids['scopus_ids'] - db_scopus_ids
       db_only_scopus_ids = db_scopus_ids - person_ids['scopus_ids']
-    
+
       for scopus_id in api_only_scopus_ids:
         person_scopus_id = PersonScopusId(
           person_uuid = db_person.uuid,
           scopus_id = scopus_id,
         )
         session.add(person_scopus_id)
-    
+
       session.query(PersonScopusId).filter(
         PersonScopusId.person_uuid == db_person.uuid,
         PersonScopusId.scopus_id.in_(db_only_scopus_ids)

--- a/experts_etl/transformer_loaders/pure_api_pub.py
+++ b/experts_etl/transformer_loaders/pure_api_pub.py
@@ -375,7 +375,7 @@ def run(
             for pub_person_pure_org in pub_person_pure_orgs:
                 session.add(pub_person_pure_org)
 
-            progessed_api_pub_uuids.append(api_pub.uuid)
+            processed_api_pub_uuids.append(api_pub.uuid)
             if len(processed_api_pub_uuids) >= transaction_record_limit:
                 mark_api_pubs_as_processed(session, pure_api_record_logger, processed_api_pub_uuids)
                 processed_api_pub_uuids = []

--- a/experts_etl/transformer_loaders/pure_api_pub.py
+++ b/experts_etl/transformer_loaders/pure_api_pub.py
@@ -1,4 +1,3 @@
-import dotenv_switch
 from datetime import datetime, timezone
 import json
 import itertools

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,7 +77,7 @@ python_dotenv = "^0.10.3"
 [package.source]
 reference = "e4e2293be560a587b86d93acaa8ee5f79306230a"
 type = "git"
-url = "git://github.com/mberkowski/dotenv_switch.git"
+url = "git://github.com/UMNLibraries/dotenv_switch.git"
 [[package]]
 category = "main"
 description = ""
@@ -411,7 +411,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "9942ea58c7aacdf15db86ce4dcd680f004b2639287d2d1d9f0e8e74b54fc55f0"
+content-hash = "7dc175230caae1e1ba74b9d60857d1ef72c831e3afe8908d64607ae3a96a77b2"
 python-versions = "^3.6.3"
 
 [metadata.hashes]

--- a/poetry.lock
+++ b/poetry.lock
@@ -69,13 +69,13 @@ description = ""
 name = "dotenv-switch"
 optional = false
 python-versions = "^3.6.3"
-version = "0.0.1"
+version = "0.1.0"
 
 [package.dependencies]
 python_dotenv = "^0.10.3"
 
 [package.source]
-reference = "d48cf28d27fe184a47be641968e0add92fac585b"
+reference = "e4e2293be560a587b86d93acaa8ee5f79306230a"
 type = "git"
 url = "git://github.com/mberkowski/dotenv_switch.git"
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -66,6 +66,21 @@ version = "0.15.2"
 [[package]]
 category = "main"
 description = ""
+name = "dotenv-switch"
+optional = false
+python-versions = "^3.6.3"
+version = "0.0.1"
+
+[package.dependencies]
+python_dotenv = "^0.10.3"
+
+[package.source]
+reference = "d48cf28d27fe184a47be641968e0add92fac585b"
+type = "git"
+url = "git://github.com/mberkowski/dotenv_switch.git"
+[[package]]
+category = "main"
+description = ""
 name = "experts-dw"
 optional = false
 python-versions = "^3.6.3"
@@ -82,6 +97,7 @@ sqlparse = "*"
 reference = "e71c790cd603240a2613d8d7f9083ebc0a638370"
 type = "git"
 url = "git://github.com/UMNLibraries/experts_dw.git"
+
 [[package]]
 category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -211,6 +227,7 @@ tenacity = "*"
 reference = "bf7a01d480bd5d501221a0a160e6515d77a9cfec"
 type = "git"
 url = "git://github.com/UMNLibraries/pureapi.git"
+
 [[package]]
 category = "dev"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -394,7 +411,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "9bf1e73f6c9ca449ef35bf0e016921f826d35adb14215820e4ace5e420c38524"
+content-hash = "9942ea58c7aacdf15db86ce4dcd680f004b2639287d2d1d9f0e8e74b54fc55f0"
 python-versions = "^3.6.3"
 
 [metadata.hashes]
@@ -406,6 +423,7 @@ chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "
 colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
 cx-oracle = ["0afe9a8028c735dbe691ccf64434c8f01eac07f71a37ae2087c0e16ec1ab56c5", "1010dfc44edbfdf3e839a7072b27f24fcdd92ddedfecfc52c40ccd61b825f54c", "14435434be6b3f2acdbde7f4116a656b5b542564228c7e1c198fadb49aceafa4", "2bd9b039f9521e48def9d8d946d36bfe84f7f7134894f5d4089f30b064032ece", "406b312a1a6e6ee79bd530bb4390947857bd3ccc060251e56a53024bfd73e6ce", "4d5ae9d689cb73eb6e9af3a714e3afbfc656b7ffad25e20ee8389f6ea9be0514", "67511f0a11dbd4fbe697917a69d2c5a709d4469986ed7a4afb79a562a719643c", "a78e3b299c859c21da25cbb842bb414d8fd0f59064a6cb099db7de0517b6559c", "c036f119039597ae7415e9c95fab2d031679bd7ed3bcb48a98853a6b049a700c", "ce511dc758f2a7f92396c883b7fca7164b184e3900cbf4b92f2378bacbca688f", "f52ab4006bdcbddab40953a682627e27fc116906e3172911f2fcb67f1332b188", "f6a1285e0d036904a96ad8c30a27f5db419c0233f9157a30db0b5c09d85e34e5", "f6d8ad337bcbda5413ff0b45cd3a47468766843f397abb32c0dc2d7d52167634", "f9bedfccef9a8a36b27247996d7b9be31b4160bf60eb0d981143d0e08573bbb2"]
 docutils = ["6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0", "9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827", "a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"]
+dotenv-switch = []
 experts-dw = []
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
 importlib-metadata = ["aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26", "d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "experts_etl"
 version = "4.1.0"
 description = "Moves data from UMN to Pure (Experts@Minnesota), and vice versa."
 readme = "README.md"
-authors = ["David Naughton <naughton@umn.edu>"]
+authors = ["David Naughton <naughton@umn.edu>", "Michael Berkowski <mjb@umn.edu"]
 license = "MIT"
 
 [tool.poetry.dependencies]
@@ -13,7 +13,7 @@ jinja2 = ">=2.10.1"
 pandas = "*"
 pureapi = {git = "git://github.com/UMNLibraries/pureapi.git"}
 python-daemon = "*"
-dotenv_switch = {git = "git://github.com/mberkowski/dotenv_switch.git"}
+dotenv_switch = {git = "git://github.com/UMNLibraries/dotenv_switch.git"}
 python-json-logger = "*"
 schedule = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ jinja2 = ">=2.10.1"
 pandas = "*"
 pureapi = {git = "git://github.com/UMNLibraries/pureapi.git"}
 python-daemon = "*"
-python_dotenv = "*"
+dotenv_switch = {git = "git://github.com/mberkowski/dotenv_switch.git"}
 python-json-logger = "*"
 schedule = "*"
 

--- a/runner.py
+++ b/runner.py
@@ -1,5 +1,4 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch.auto
 import importlib
 import multiprocessing as mp
 import os
@@ -11,7 +10,7 @@ experts_etl_logger = loggers.experts_etl_logger()
 default_interval = 14400 # 4 hours, in seconds
 
 extractor_loaders = list(map(
-  lambda x: 'experts_etl.extractor_loaders.' + x, 
+  lambda x: 'experts_etl.extractor_loaders.' + x,
   [
     'pure_api_changes',
     'pure_api_external_organisations',
@@ -23,7 +22,7 @@ extractor_loaders = list(map(
 ))
 
 transformer_loaders = list(map(
-  lambda x: 'experts_etl.transformer_loaders.' + x, 
+  lambda x: 'experts_etl.transformer_loaders.' + x,
   [
     'pure_api_external_org',
     'pure_api_internal_org',
@@ -34,7 +33,7 @@ transformer_loaders = list(map(
 ))
 
 syncers = list(map(
-  lambda x: 'experts_etl.' + x, 
+  lambda x: 'experts_etl.' + x,
   [
     'oit_to_edw.person',
     'edw_to_pure.person',
@@ -85,7 +84,7 @@ def run():
     }
   )
 
-  for module_name in extractor_loaders + transformer_loaders + syncers: 
+  for module_name in extractor_loaders + transformer_loaders + syncers:
     try:
       # Must include a comma after a single arg, or multiprocessing seems to
       # get confused and think we're passing multiple arguments:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,1 @@
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
+import dotenv_switch

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-import dotenv_switch
+import dotenv_switch.auto


### PR DESCRIPTION
Mainly, this is to load dotenv .env files via `dotenv_switch.auto` as in 
https://github.com/UMNLibraries/experts_etl/compare/dotenv-switch?expand=1#diff-2ef65ef8520cef01c37a957e90545296R1

Additionally:
- all `dotenv_load()` calls removed from individual etl modules, allowing it all to inherit from `runner.py` or `tests/__init__.py`
- Trailing whitespace auto-removed by .editorconfig