### PR TITLE
Project authors typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "experts_etl"
 version = "5.19.6"
 description = "Moves data from UMN to Pure (Experts@Minnesota), and vice versa."
 readme = "README.md"
-authors = ["David Naughton <naughton@umn.edu>", "Michael Berkowski <mjb@umn.edu"]
+authors = ["David Naughton <naughton@umn.edu>", "Michael Berkowski <mjb@umn.edu>"]
 license = "MIT"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Just noticed a missing `>` in my email address on the toml authors list, but actually you can decide whether to keep me on there at all. I'd be fine if I was removed, and @johnbarneson should be added instead.